### PR TITLE
Fix nvim-treesitter-context not being loaded and make it toggleable

### DIFF
--- a/lua/nils/configuration/telescope.lua
+++ b/lua/nils/configuration/telescope.lua
@@ -77,8 +77,8 @@ function conf.telescope()
       qflist_previewer = previewers.vim_buffer_qflist.new,
       mappings = {
         i = {
-              ["<C-x>"] = false,
-              ["<C-q>"] = actions.send_to_qflist,
+          ["<C-x>"] = false,
+          ["<C-q>"] = actions.send_to_qflist,
         },
       },
     },
@@ -109,6 +109,7 @@ function conf.telescope()
                 TransparentToggle()
               end,
             },
+            { "Toggle Treesitter Context",    "TSContextToggle" },
             { "LSP Restart",                  "LspRestart" },
             { "Remove all // comments",       "%s/\\/\\/.*//g" },
             { "Remove all # comments",        "%s/#.*//g" },

--- a/lua/nils/plugins/treesitter.lua
+++ b/lua/nils/plugins/treesitter.lua
@@ -12,6 +12,7 @@ return {
   },
   {
     "romgrk/nvim-treesitter-context",
+    event = "BufEnter",
     after = "nvim-treesitter",
     config = conf.treesittercontext,
   },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/66632359/229219543-d815f9e3-825e-4789-8196-2292fcfb9f77.png)![image](https://user-images.githubusercontent.com/66632359/229219327-fe5f188a-37f1-42bd-a9c9-14a1d1e4132d.png)
![image](https://user-images.githubusercontent.com/66632359/229219806-d60d803e-5b48-4198-b836-da0231660748.png)
